### PR TITLE
Update Windows Jenkins Agent init script to keep the connection opened indefinitely

### DIFF
--- a/powershell/Jenkins-Windows-Init-Script-no-secrets.ps1
+++ b/powershell/Jenkins-Windows-Init-Script-no-secrets.ps1
@@ -30,11 +30,20 @@ $destSource = "d:\java\slave.jar"
 $wc = New-Object System.Net.WebClient
 $wc.DownloadFile($slaveSource, $destSource)
 
-# execute slave
-Write-Output "Executing slave process "
+# execute agent
+Write-Output "Executing agent process "
 $java="d:\java\zulu1.7.0_51-7.3.0.4-win64\bin\java.exe"
 $jar="-jar"
 $jnlpUrl="-jnlpUrl"
 $secretFlag="-secret"
 $serverURL=$jenkinsserverurl+"computer/" + $vmname + "/slave-agent.jnlp"
-& $java $jar $destSource $secretFlag $secret $jnlpUrl $serverURL
+while ($true) {
+  try {
+    # Launch
+    & $java -jar $destSource $secretFlag  $secret $jnlpUrl $serverURL -noReconnect
+  }
+  catch [System.Exception] {
+    Write-Output $_.Exception.ToString()
+  }
+  Start-Sleep 10
+}


### PR DESCRIPTION
The previous version would exit after some time, leaving the Jenkins agent unusable