### PR TITLE
add-docker-build-job: Install aditional plugins

### DIFF
--- a/jenkins/add-docker-build-job.sh
+++ b/jenkins/add-docker-build-job.sh
@@ -181,7 +181,7 @@ job_xml=${job_xml//'{insert-groovy-script}'/"$(curl -s ${artifacts_location}/jen
 echo "${job_xml}" > job.xml
 function retry_until_successful {
     counter=0
-    ${@}
+    "${@}"
     while [ $? -ne 0 ]; do
         if [[ "$counter" -gt 20 ]]; then
             exit 1
@@ -203,9 +203,9 @@ fi
 
 #install the required plugins
 retry_until_successful java -jar jenkins-cli.jar -s ${jenkins_url} install-plugin "credentials" -deploy --username ${jenkins_user_name} --password ${jenkins_password}
-retry_until_successful java -jar jenkins-cli.jar -s ${jenkins_url} install-plugin "workflow-cps" -deploy --username ${jenkins_user_name} --password ${jenkins_password}
-retry_until_successful java -jar jenkins-cli.jar -s ${jenkins_url} install-plugin "workflow-job" -deploy --username ${jenkins_user_name} --password ${jenkins_password}
+retry_until_successful java -jar jenkins-cli.jar -s ${jenkins_url} install-plugin "workflow-aggregator" -deploy --username ${jenkins_user_name} --password ${jenkins_password}
 retry_until_successful java -jar jenkins-cli.jar -s ${jenkins_url} install-plugin "docker-workflow" -restart --username ${jenkins_user_name} --password ${jenkins_password}
+retry_until_successful java -jar jenkins-cli.jar -s ${jenkins_url} install-plugin "git" -restart --username ${jenkins_user_name} --password ${jenkins_password}
 
 #wait for instance to be back online
 retry_until_successful java -jar jenkins-cli.jar -s ${jenkins_url} version --username ${jenkins_user_name} --password ${jenkins_password}

--- a/quickstart_template/201-jenkins-to-azure-container-registry.sh
+++ b/quickstart_template/201-jenkins-to-azure-container-registry.sh
@@ -114,5 +114,5 @@ if [[ "${include_docker_build_pipeline}" == "1" ]]
 then
     echo "Including the pipeline"
 
-    curl --silent "${artifacts_location}/jenkins/add-docker-build-job.sh${artifacts_location_sas_token}" | sudo bash -s -- -j "http://localhost:8080/" -ju "admin" -g "${git_url}" -r "${registry}" -ru "${registry_user_name}"  -rp "${registry_password}" -rr "$repository" -sps "* * * * *"
+    curl --silent "${artifacts_location}/jenkins/add-docker-build-job.sh${artifacts_location_sas_token}" | sudo bash -s -- -j "http://localhost:8080/" -ju "admin" -g "${git_url}" -r "${registry}" -ru "${registry_user_name}"  -rp "${registry_password}" -rr "$repository" -sps "* * * * *" -al "$artifacts_location" -st "$artifacts_location_sas_token"
 fi

--- a/quickstart_template/201-jenkins-to-azure-container-registry.sh
+++ b/quickstart_template/201-jenkins-to-azure-container-registry.sh
@@ -30,8 +30,6 @@ function throw_if_empty() {
 #defaults
 include_docker_build_pipeline="0"
 artifacts_location="https://raw.githubusercontent.com/Azure/azure-devops-utils/master/"
-repository="${vm_user_name}/myfirstapp"
-
 while [[ $# > 0 ]]
 do
   key="$1"
@@ -90,6 +88,10 @@ then
     throw_if_empty --registry $registry
     throw_if_empty --registry_user_name $registry_user_name
     throw_if_empty --registry_password $registry_password
+fi
+
+if [ -z "$repository" ]; then
+  repository="${vm_user_name}/myfirstapp"
 fi
 
 #install jenkins


### PR DESCRIPTION
If the polling option is enabled then the first build will occur before the user can install suggested plugins.
The updated script install all the necessary plugins so the build is successful.

During testing I found other small issues in the quickstart template scripts:
* the artifacts location was not passed along
* the default repository name was broken