### PR TITLE
Set the default jenkins workspace in drive D

### DIFF
--- a/powershell/Jenkins-Windows-Init-Script-no-secrets.ps1
+++ b/powershell/Jenkins-Windows-Init-Script-no-secrets.ps1
@@ -5,6 +5,8 @@ $jenkinsserverurl = $args[0]
 $vmname = $args[1]
 $secret = $args[2]
 
+#Default workspace location
+Set-Location d:\
 
 # Download the file to a specific location
 Write-Output "Downloading zulu SDK "


### PR DESCRIPTION
By default the default workspace was in 'C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\1.8\Downloads\0\' and the odds of getting a path too long error were high.
I've changed that to 'D:\'