### PR TITLE
Deprecate create-service-principal.sh script

### DIFF
--- a/bash/create-service-principal.sh
+++ b/bash/create-service-principal.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 
-#echo "Usage:
-#  1 bash create-service-principal.sh
-#  2 bash create-service-principal.sh <Subscription ID>
-# You need Azure CLI: https://docs.microsoft.com/azure/xplat-cli-install
+cat <<EOF
+********************************************** WARNING **********************************************
+This script uses the Azure CLI 1.0 and has been deprecated. Please install the Azure CLI 2.0
+(https://docs.microsoft.com/cli/azure/install-azure-cli) and use these 3 easy commands:
+
+  az login
+  az account set --subscription <Subscription ID>
+  az ad sp create-for-rbac
+
+By default, the last command creates a Service Principal with the 'Contributor' role scoped to the
+current subscription. Pass the '--help' parameter for more info if you want to change the defaults.
+********************************************** WARNING **********************************************
+EOF
+
+if !(command -v azure >/dev/null); then
+  echo "ERROR: This script requires Azure CLI 1.0, but it could not be found. Is it installed and on your path?" 1>&2
+  exit -1
+fi
 
 SUBSCRIPTION_ID=$1
 


### PR DESCRIPTION
We refer users to this script in several places (at least in the jenkins agents plugin and jenkins credentials plugin), but the experience in the Azure cli 2.0 is much better and doesn't require a script.

We should update all of our documentation to use the Azure cli 2.0 command, but I've added a warning here in the mean-time.

I also added an error if we can't find the azure cli 1.0 (rather than letting the script continue and give the user a bunch of errors)