### PR TITLE
Move spinnaker scripts to AZ cli 2.0

### DIFF
--- a/quickstart_template/301-jenkins-acr-spinnaker-k8s.sh
+++ b/quickstart_template/301-jenkins-acr-spinnaker-k8s.sh
@@ -14,7 +14,6 @@ Arguments
   --git_repository|-gr               [Required] : Git URL with a Dockerfile in it's root
   --resource_group|-rg               [Required] : Resource group containing your Kubernetes cluster
   --master_fqdn|-mf                  [Required] : Master FQDN of your Kubernetes cluster
-  --master_count|-mc                 [Required] : Master count of your Kubernetes cluster
   --storage_account_name|-san        [Required] : Storage Account name used for Spinnaker's persistent storage
   --storage_account_key|-sak         [Required] : Storage Account key used for Spinnaker's persistent storage
   --azure_container_registry|-acr    [Required] : Azure Container Registry url
@@ -89,10 +88,6 @@ do
       master_fqdn="$1"
       shift
       ;;
-    --master_count|-mc)
-      master_count="$1"
-      shift
-      ;;
     --storage_account_name|-san)
       storage_account_name="$1"
       shift
@@ -143,7 +138,6 @@ throw_if_empty --user_name $user_name
 throw_if_empty --git_repository $git_repository
 throw_if_empty --resource_group $resource_group
 throw_if_empty --master_fqdn $master_fqdn
-throw_if_empty --master_count $master_count
 throw_if_empty --storage_account_name $storage_account_name
 throw_if_empty --storage_account_key $storage_account_key
 throw_if_empty --azure_container_registry $azure_container_registry
@@ -156,7 +150,7 @@ pipeline_registry="$azure_container_registry"
 front50_port="8081"
 
 # Configure Spinnaker (do this first because the default InstallSpinnaker.sh script sets up front50 on port 8080 and that might fail if we did Jenkins first)
-run_util_script "quickstart_template/201-spinnaker-acr-k8s.sh" -ai "$app_id" -ak "$app_key" -si "$subscription_id" -ti "$tenant_id" -un "$user_name" -rg "$resource_group" -mf "$master_fqdn" -mc "$master_count" -san "$storage_account_name" -sak "$storage_account_key" -acr "$azure_container_registry" -ikp "$include_kubernetes_pipeline" -prg "$pipeline_registry" -prp "$docker_repository" -pp "$pipeline_port" -fp "$front50_port" -al "$artifacts_location" -st "$artifacts_location_sas_token"
+run_util_script "quickstart_template/201-spinnaker-acr-k8s.sh" -ai "$app_id" -ak "$app_key" -si "$subscription_id" -ti "$tenant_id" -un "$user_name" -rg "$resource_group" -mf "$master_fqdn" -san "$storage_account_name" -sak "$storage_account_key" -acr "$azure_container_registry" -ikp "$include_kubernetes_pipeline" -prg "$pipeline_registry" -prp "$docker_repository" -pp "$pipeline_port" -fp "$front50_port" -al "$artifacts_location" -st "$artifacts_location_sas_token"
 
 # Configure Jenkins
 run_util_script "quickstart_template/201-jenkins-acr.sh" -u "$user_name" -g "$git_repository" -r "https://$azure_container_registry" -ru "$app_id" -rp "$app_key" -rr "$docker_repository" -jf "$jenkins_fqdn" -al "$artifacts_location" -st "$artifacts_location_sas_token"

--- a/spinnaker/copy_kube_config/README.md
+++ b/spinnaker/copy_kube_config/README.md
@@ -5,7 +5,7 @@ Programatically copies a kubeconfig file from an Azure Container Service Kuberne
 >**Note:** This script is only intended for use when copying the kubeconfig programatically with a Service Principal (aka when you do not have access to the ssh private key). If you want to do this manually, you can simply use 'scp'.
 
 ## Prerequisites
-This must be executed on a machine with an existing Spinnaker instance. The 'azure' cli must be installed and you must already be logged in with the correct subscription set.
+This must be executed on a machine with an existing Spinnaker instance. The 'az' cli must be installed and you must already be logged in with the correct subscription set.
 
 ## Arguments
 | Name | Description |
@@ -13,11 +13,10 @@ This must be executed on a machine with an existing Spinnaker instance. The 'azu
 | --user_name<br/>-un | The admin user name for the Kubernetes cluster. |
 | --resource_group<br/>-rg | The resource group containing the Kubernetes cluster. |
 | --master_fqdn<br/>-mf | The FQDN for the master VMs in the Kubernetes cluster. |
-| --master_count<br/>-mc | The count of master VMs in the Kubernetes cluster. |
 
 ## Example usage
 ```bash
-./copy_kube_config.sh --user_name "adminuser" --resource_group "resourcegroup" --master_fqdn "samplemgmt.westus.cloudapp.azure.com" --master_count 1
+./copy_kube_config.sh --user_name "adminuser" --resource_group "resourcegroup" --master_fqdn "samplemgmt.westus.cloudapp.azure.com"
 ```
 
 ## Questions/Comments? azdevopspub@microsoft.com

--- a/spinnaker/copy_kube_config/copy_kube_config.sh
+++ b/spinnaker/copy_kube_config/copy_kube_config.sh
@@ -3,15 +3,14 @@
 function print_usage() {
   cat <<EOF
 Command
-  $0 
+  $0
 
 Arguments
   --user_name|-un          [Required]: User name for Kubernetes cluster
   --resource_group|-rg     [Required]: Resource group containing Kubernetes cluster
   --master_fqdn|-mf        [Required]: Master FQDN of Kubernetes master VMs
-  --master_count|-mc       [Required]: Count of Kubernetes master VMs
 
-NOTE: This script requires the 'azure' cli and assumes you have logged in and set the correct subscription
+NOTE: This script requires the 'az' cli and assumes you have logged in and set the correct subscription
 EOF
 }
 
@@ -42,10 +41,6 @@ do
       master_fqdn="$1"
       shift
       ;;
-    --master_count|-mc)
-      master_count="$1"
-      shift
-      ;;
     --help|-help|-h)
       print_usage
       exit 13
@@ -59,23 +54,8 @@ done
 throw_if_empty --user-name $admin_user_name
 throw_if_empty --resource_group $resource_group
 throw_if_empty --master_fqdn $master_fqdn
-throw_if_empty --master_count $master_count
 
 destination_file="/home/spinnaker/.kube/config"
-
-# Get the unique suffix used for kubernetes vms
-
-kubernetes_suffix=$(azure group deployment list $resource_group --json | python -c "
-import json, sys;
-data=json.load(sys.stdin);
-for deployment in data:
-  try:
-    if deployment['properties']['outputs']['masterFQDN']['value'] == '$master_fqdn':
-      print deployment['properties']['parameters']['nameSuffix']['value']
-      sys.exit(0)
-  except:
-    pass
-")
 
 # Setup temporary credentials to access kubernetes master vms
 temp_user_name=$(uuidgen | sed 's/-//g')
@@ -83,25 +63,26 @@ temp_key_path=$(mktemp -d)/temp_key
 ssh-keygen -t rsa -N "" -f $temp_key_path -V "+1d"
 temp_pub_key=$(cat ${temp_key_path}.pub)
 
+master_vm_ids=$(az vm list -g "$resource_group" --query "[].id" -o tsv | grep "k8s-master-")
+>&2 echo "Master VM ids: $master_vm_ids"
+
 # Enable temporary credentials on every kubernetes master vm (since we don't know which vm will be used when we scp)
-for (( i=0; i<$master_count; i++ ))
-do
-  master_vm="k8s-master-${kubernetes_suffix}-$i"
-  azure vm extension set $resource_group $master_vm VMAccessForLinux Microsoft.OSTCExtensions 1.4 --private-config "{ \"username\": \"$temp_user_name\", \"ssh_key\": \"$temp_pub_key\" }"
-done
+az vm user update -u "$temp_user_name" --ssh-key-value "$temp_pub_key" --ids "$master_vm_ids"
 
 # Copy kube config over from master kubernetes cluster and mark readable
 sudo mkdir -p $(dirname "$destination_file")
 sudo sh -c "ssh -o StrictHostKeyChecking=no -i \"$temp_key_path\" $temp_user_name@$master_fqdn sudo cat /home/$admin_user_name/.kube/config > \"$destination_file\""
-sudo chmod +r $destination_file
 
 # Remove temporary credentials on every kubernetes master vm
-for (( i=0; i<$master_count; i++ ))
-do
-  master_vm="k8s-master-${kubernetes_suffix}-$i"
-  azure vm extension set $resource_group $master_vm VMAccessForLinux Microsoft.OSTCExtensions 1.4 --private-config "{ \"remove_user\": \"$temp_user_name\" }"
-done
+az vm user delete -u "$temp_user_name" --ids "$master_vm_ids"
 
 # Delete temp key on spinnaker vm
 rm $temp_key_path
 rm ${temp_key_path}.pub
+
+if [ ! -s "$destination_file" ]; then
+  >&2 echo "Failed to copy kubeconfig for kubernetes cluster."
+  exit -1
+fi
+
+sudo chmod +r "$destination_file"


### PR DESCRIPTION
And throw an error if we fail to copy the kubeconfig. This happens every once in a while and is generally hard for the user to figure out what went wrong. Better to just fail