### PR TITLE
Fix command usage in deploy-dev-ops

### DIFF
--- a/deploy-dev-ops/deploy-dev-ops.sh
+++ b/deploy-dev-ops/deploy-dev-ops.sh
@@ -8,7 +8,7 @@
 function print_usage() {
   cat <<EOF
 Command
-  $0
+  ./deploy-dev-ops.sh
 
 Arguments:
   --subscription_id|-s   : Subscription id, optional if a default is already set in the Azure CLI


### PR DESCRIPTION
When you run 'curl -sL https://aka.ms/DeployDevOps | bash -s -- --help', it just displays as:
Command
  bash

So hard code the value instead