### PR TITLE
Add ability to install weekly Jenkins releases

### DIFF
--- a/jenkins/install_jenkins.sh
+++ b/jenkins/install_jenkins.sh
@@ -76,6 +76,10 @@ done
 
 throw_if_empty --jenkins_fqdn $jenkins_fqdn
 throw_if_empty --jenkins_release_type $jenkins_release_type
+if [[ "$jenkins_release_type" != "LTS" ]] && [[ "$jenkins_release_type" != "weekly" ]]; then
+  echo "Parameter jenkins_release_type can only be 'LTS' or 'weekly'! Current value is '$jenkins_release_type'"
+  exit 1
+fi
 
 if [ -z "$vm_private_ip" ]; then
     #use port 80 for public fqdn

--- a/jenkins/install_jenkins.sh
+++ b/jenkins/install_jenkins.sh
@@ -183,10 +183,15 @@ else
   sudo sh -c 'echo deb http://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list'
 fi
 
+sudo add-apt-repository ppa:openjdk-r/ppa --yes
+
 echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
 sudo apt-get install apt-transport-https
 sudo apt-get update --yes
+
+#install openjdk8
+sudo apt-get install openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk --yes
 
 #install jenkins
 sudo apt-get install jenkins --yes

--- a/solution_template/jenkins/MainTemplate.json
+++ b/solution_template/jenkins/MainTemplate.json
@@ -109,6 +109,13 @@
       },
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
+    },
+    "jenkinsReleaseType": {
+      "metadata": {
+        "description": "Jenkins release type (LTS or weekly)"
+      },
+      "type": "string",
+      "defaultValue": "LTS"
     }
   },
   "variables": {
@@ -343,7 +350,7 @@
       "properties": {
         "autoUpgradeMinorVersion": true,
         "protectedSettings": {
-          "commandToExecute": "[concat('./' , variables('_extensionScript'), ' -jf \"', reference(variables('publicIPDeploymentName')).outputs.fqdn.value, '\" -pi \"', variables('vmPrivateIP'), '\" -al \"', parameters('_artifactsLocation'), '\" -st \"', parameters('_artifactsLocationSasToken'), '\"' )]"
+          "commandToExecute": "[concat('./' , variables('_extensionScript'), ' -jf \"', reference(variables('publicIPDeploymentName')).outputs.fqdn.value, '\" -pi \"', variables('vmPrivateIP'), '\" -jrt \"', parameters('jenkinsReleaseType') , '\" -al \"', parameters('_artifactsLocation'), '\" -st \"', parameters('_artifactsLocationSasToken'), '\"' )]"
         },
         "publisher": "Microsoft.Azure.Extensions",
         "settings": {


### PR DESCRIPTION
* install_jenkins.sh now allows installing Jenkins weekly releases (by default it still installs the LTS version)
* Also updated the solution template, so we can add a test job that verifies against the weekly releases.

@chenkennt I think this is a very good way for you and your team to get acquainted with the quickstart templates. If you're interested, update the quickstart templates to use this version and update the CI test jobs. 