### PR TITLE
update to tell customers that MS doesn't provide official support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ This repository contains utility scripts to run/configure DevOp systems in Azure
 
 ## Questions/Comments? azdevopspub@microsoft.com
 
+ Sample scripts in this quickstart are not supported under any Microsoft standard support program or service. The sample scripts are provided AS IS without warranty of any kind. Microsoft disclaims all implied warranties including, without limitation, any implied warranties of merchantability or of fitness for a particular purpose. The entire risk arising out of the use or performance of the sample scripts and documentation remains with you. In no event shall Microsoft, its authors, or anyone else involved in the creation, production, or delivery of the scripts be liable for any damages whatsoever (including, without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
+
 _This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments._


### PR DESCRIPTION
1- azdevopspub@microsoft.com isn't a valid address anymore
2- from CRI 71338271 - it looks like nobody owns or supports https://github.com/Azure/azure-devops-utils/blob/master/quickstart_template/301-jenkins-acr-spinnaker-k8s.sh from Microsoft - so we should add a disclaimer saying that no official Support from Microsoft can be provided.