### PR TITLE
Fix VM extension script for spinnaker and Jenkins setup

### DIFF
--- a/jenkins/add-aptly-build-job.sh
+++ b/jenkins/add-aptly-build-job.sh
@@ -42,7 +42,7 @@ job_display_name="Sample Aptly Job"
 job_description="A basic pipeline that builds a debian package and pushes it to an Aptly repository hosted on the Jenkins VM."
 repository_name="hello-karyon-rxnetty"
 artifacts_location="https://raw.githubusercontent.com/Azure/azure-devops-utils/master/"
-git_url="https://github.com/azure-devops/hello-karyon-rxnetty.git"
+git_url="https://github.com/mybayern1974/hello-karyon-rxnetty.git"
 
 while [[ $# > 0 ]]
 do

--- a/jenkins/init-aptly-repo.sh
+++ b/jenkins/init-aptly-repo.sh
@@ -50,7 +50,7 @@ throw_if_empty repository_name $repository_name
 echo "deb http://repo.aptly.info/ squeeze main" | sudo tee -a "/etc/apt/sources.list" > /dev/null
 sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 9E3E53F19C7DE460
 sudo DEBIAN_FRONTEND=noninteractive apt-get update --yes
-sudo DEBIAN_FRONTEND=noninteractive apt-get install aptly --yes
+sudo DEBIAN_FRONTEND=noninteractive apt-get install aptly --force-yes --yes
 
 # Create default aptly repository
 sudo su -c "aptly repo create $repository_name" jenkins

--- a/spinnaker/install_halyard/install_halyard.sh
+++ b/spinnaker/install_halyard/install_halyard.sh
@@ -49,8 +49,11 @@ throw_if_empty username $username
 # Install Halyard
 curl --silent "https://raw.githubusercontent.com/spinnaker/halyard/master/install/debian/InstallHalyard.sh" | sudo bash -s -- --user "$username" -y
 
+# Get the latest version of spinnaker
+version=`hal version list | grep -P '\d+\.\d+\.\d+' -o | tail -1`
+
 # Set Halyard to use the latest released/validated version of Spinnaker
-hal config version edit --version $(hal version latest -q)
+hal config version edit --version $version
 
 # Configure Spinnaker persistent store
 hal config storage azs edit --storage-account-name "$storage_account_name" --storage-account-key "$storage_account_key"

--- a/spinnaker/install_halyard/install_halyard.sh
+++ b/spinnaker/install_halyard/install_halyard.sh
@@ -47,7 +47,7 @@ throw_if_empty storage_account_key $storage_account_key
 throw_if_empty username $username
 
 # Install Halyard
-curl --silent "https://raw.githubusercontent.com/spinnaker/halyard/master/install/stable/InstallHalyard.sh" | sudo bash -s -- --user "$username" -y
+curl --silent "https://raw.githubusercontent.com/spinnaker/halyard/master/install/debian/InstallHalyard.sh" | sudo bash -s -- --user "$username" -y
 
 # Set Halyard to use the latest released/validated version of Spinnaker
 hal config version edit --version $(hal version latest -q)


### PR DESCRIPTION
Fix scripts
* `add-aptly-build-job.sh`
  * Use work-around github url
* `301-jenkins-aptly-spinnaker-vmss.sh`
  * Change the Jenkins port
  * Fix the bug that dollar sign in password will break the pipe.
  * Add conditional check before restarting the services
  * Remove unused items
* `install_halyard.sh`
  * Determine the latest version by get the last version number in `hal version list` command output
  * Use `debian` version of halyard