### PR TITLE
Fix wrong Jenkins repositories keys

### DIFF
--- a/jenkins/install_jenkins.sh
+++ b/jenkins/install_jenkins.sh
@@ -241,8 +241,9 @@ server {
 EOF
 )
 
-#update apt repositories
-wget -q -O - https://pkg.jenkins.io/debian/jenkins-ci.org.key | sudo apt-key add -
+# Add repositories public keys
+wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | sudo apt-key add -
+wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key add -
 
 if [ "$jenkins_release_type" == "weekly" ]; then
   sudo sh -c 'echo deb http://pkg.jenkins.io/debian binary/ > /etc/apt/sources.list.d/jenkins.list'


### PR DESCRIPTION
Fix the repositories public keys url for Jenkins (see https://pkg.jenkins.io/debian-stable/ and https://pkg.jenkins.io/debian/ )